### PR TITLE
Fix crash on method names that break regex patterns

### DIFF
--- a/stags/src/main/scala/co/pjrt/stags/TagGenerator.scala
+++ b/stags/src/main/scala/co/pjrt/stags/TagGenerator.scala
@@ -1,12 +1,12 @@
 package co.pjrt.stags
 
 import java.io.File
-
 import scala.meta._
 
 import co.pjrt.stags.paths.Path
 
 object TagGenerator {
+
 
   /**
    * Given a Scalameta Source, generate a sequence of [[Tag]]s for it
@@ -143,6 +143,7 @@ object TagGenerator {
 
     val static = staticParent || isStatic(scope, mods)
     def getFromPat(p: Pat) = getFromPats(scope, mods, p, staticParent, parent)
+    
     pat match {
       case p: Pat.Var      => Seq(patTag(scope, parent, p, static))
       case Pat.Typed(p, _) => getFromPat(p)
@@ -159,6 +160,9 @@ object TagGenerator {
       case _: Lit =>
         // DESNOTE(2017-07-14, pjrt): This is for patterns like `val 1 = x`
         // For those, we should not generate tags (of course)
+        Seq.empty
+      case _ => 
+        Console.err.println(s"Error matching $pat in line ${parent.syntax}")
         Seq.empty
     }
   }
@@ -332,8 +336,8 @@ private object AddressGen {
     val line = tree.tokens.syntax.lines.toList(lineWithTagName).trim
 
     val name = tagName.value
-    val replacement = s"\\\\zs$name"
-    val nameW = s"\\b$name\\b"
+    val replacement = s"\\\\zs$name".replaceAllLiterally("$","\\$")
+    val nameW = s"\\b\\Q$name\\E\\b" // wrap $name with regex quote \Q\E; and word bound \b\b
     val search = line.replaceFirst(nameW, replacement)
     s"/$search/"
   }

--- a/stags/src/test/scala/co/pjrt/stags/TagGeneratorTest.scala
+++ b/stags/src/test/scala/co/pjrt/stags/TagGeneratorTest.scala
@@ -337,6 +337,32 @@ class TagGeneratorTest extends FreeSpec with Matchers {
       (abc("SomeThing"), "some", false)
     )
   }
+  "regex dangerous methods names should create tags" in {
+    val testFile =
+      """
+      |package a.b.c
+      |object DangerMethods {
+      |  def *(v:Int): Int =  ???
+      |  def **(v:Int): Int =  ???
+      |  def ***(v:Int): Int =  ???
+      |  def ?(v:Int):Boolean =  ???
+      |  def ^(v:Int):Boolean =  ???
+      |  def question$: Int =  ???
+      |  def x$u: Int =  ???
+      |}
+      """.stripMargin
+
+    testFile ~> Seq(
+      (abc(), "DangerMethods", false),
+      (abc("DangerMethods"), "*", false),
+      (abc("DangerMethods"), "**", false),
+      (abc("DangerMethods"), "***", false),
+      (abc("DangerMethods"), "?", false),
+      (abc("DangerMethods"), "^", false),
+      (abc("DangerMethods"), "question$", false),
+      (abc("DangerMethods"), "x$u", false)
+    )
+  }
 
   "Decl defs should create tags" in {
     val testFile =
@@ -352,6 +378,7 @@ class TagGeneratorTest extends FreeSpec with Matchers {
       (Scope.empty, "declDef", false)
     )
   }
+
 
   "should ignore @annotations" in {
     val testFile =

--- a/stags/src/test/scala/co/pjrt/stags/TagLineTest.scala
+++ b/stags/src/test/scala/co/pjrt/stags/TagLineTest.scala
@@ -59,8 +59,9 @@ class TagLineTest extends FreeSpec with Matchers {
       TagLine(tag, filePath)
         .relativize(target)
         .filePath
-        .toString shouldBe expectedS
-
+        .toString
+        .replaceAllLiterally("\\","/") //windows path sep is backwards
+        .shouldBe(expectedS)
     }
 
     "should modify the filepath to be relative from the target in" - {


### PR DESCRIPTION
Note, this pull request was not specifically tested.  However, it has been tested in the branch `drxcc/stags/dep-updates` which bumps the project to sbt 1.0.

These changes fix tag generation for a broader number of repositories including `scala/scala` and `sbt/sbt`.