### PR TITLE
Update dependencies (sbt-1.1.1, scala-meta, sbt-release and more)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ import ReleaseTransformations._
 lazy val stags =
   (project in file("stags"))
     .settings(
-      libraryDependencies += "org.scalameta" %% "scalameta" % "2.1.2"
+      libraryDependencies += "org.scalameta" %% "scalameta" % "3.3.1"
     )
 
 lazy val cli =
@@ -17,7 +17,7 @@ lazy val cli =
     .dependsOn(stags % "compile->compile;test->test")
     .settings(
       name := "stags-cli",
-      libraryDependencies += "com.github.scopt" %% "scopt" % "3.5.0",
+      libraryDependencies += "com.github.scopt" %% "scopt" % "3.7.0",
       mainClass in assembly := Some("co.pjrt.stags.cli.Main"),
       buildInfoKeys := Seq[BuildInfoKey](version),
       buildInfoPackage := "co.pjrt.stags.cli.build",
@@ -28,5 +28,10 @@ lazy val root = (project in file("."))
   .aggregate(stags, cli)
   .settings(
     // Don't publish useless root artifacts
-    packagedArtifacts := Map.empty
+    packagedArtifacts := Map.empty,
+    //--prevent project publishing https://github.com/sbt/sbt/issues/313rf
+    publish := {},
+    publishLocal := {},
+    publishM2 := {},
+    publishArtifact := false //prevent publishing the root project in sbt0.13
   )

--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ lazy val root = (project in file("."))
   .settings(
     // Don't publish useless root artifacts
     packagedArtifacts := Map.empty,
-    //--prevent project publishing https://github.com/sbt/sbt/issues/313rf
+    //--prevent project publishing https://github.com/sbt/sbt/issues/3136
     publish := {},
     publishLocal := {},
     publishM2 := {},

--- a/project/Project.scala
+++ b/project/Project.scala
@@ -29,7 +29,7 @@ object ProjectPlugin extends AutoPlugin {
   override def buildSettings =
     Seq(
       organization := "co.pjrt",
-      scalaVersion := "2.12.2",
+      scalaVersion := "2.12.4",
       releaseVersionFile := baseDirectory.value / "version.sbt",
       sonatypeProfileName := "co.pjrt",
       resolvers ++= Seq(
@@ -62,11 +62,11 @@ object ProjectPlugin extends AutoPlugin {
         setReleaseVersion,
         commitReleaseVersion,
         tagRelease,
-        ReleaseStep(action = Command.process("stags/publishSigned", _)),
-        ReleaseStep(action = Command.process("cli/publishSigned", _)),
+        releaseStepCommand("stags/publishSigned"),
+        releaseStepCommand("cli/publishSigned"),
         setNextVersion,
         commitNextVersion,
-        ReleaseStep(action = Command.process("sonatypeReleaseAll", _)),
+        releaseStepCommand("sonatypeReleaseAll"),
         pushChanges
       )
     )
@@ -76,6 +76,6 @@ object ProjectPlugin extends AutoPlugin {
       scalacOptions := scalacOps,
       scalacOptions in (Compile, console) ~=
         (_.filterNot(_ == "-Ywarn-unused-import")),
-      libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.1" % "test"
+      libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5" % "test"
     )
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.1.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,6 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.4")
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.8.0")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.5")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.2")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0") //1.0.1
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.7")


### PR DESCRIPTION
Note: these updates build on the `regex-method` fix.   

The build and CLI tool was tested against several community projects including `scala/scala` and `sbt/sbt`.

FYI, running `stags` after cloning several projects into my `~/Projects` folder such as a `~/Projects/scala`, `~/Projects/sbt` and more successfully produced a 18MB `~/Projects/tags` file with a number of warnings printed to standard err all related to syntax error battle tests in the scala build. 